### PR TITLE
Add empty implements

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -1,0 +1,28 @@
+package gcf
+
+type emptyIterable[T any] struct {
+}
+
+type emptyIterator[T any] struct {
+	current T
+}
+
+func empty[T any]() Iterable[T] {
+	return emptyIterable[T]{}
+}
+
+func (itb emptyIterable[T]) Iterator() Iterator[T] {
+	return emptyIter[T]()
+}
+
+func emptyIter[T any]() Iterator[T] {
+	return &emptyIterator[T]{}
+}
+
+func (it *emptyIterator[T]) MoveNext() bool {
+	return false
+}
+
+func (it *emptyIterator[T]) Current() T {
+	return it.current
+}


### PR DESCRIPTION
- empty()の実装を専用のIterableとIteratorに変更
    - sliceIteratorより処理を軽くできるのでこちらを採用した
    - Emptyを外部で利用したいニーズがあればそのうちExportedにするかも