### PR TITLE
Common test

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,26 @@
+package gcf_test
+
+import (
+	"testing"
+
+	"github.com/meian/gcf"
+	"github.com/stretchr/testify/assert"
+)
+
+// testBeforeAndAfter tests Iterator before calling first MoveNext or after gone last MoveNext.
+// On bofore calling first, Iterator.Current() should be zero value.
+// On after gone last, Iterator.MoveNext() should be false, and Iterator.Current() should be zero value.
+func testBeforeAndAfter[T any](t *testing.T, itb gcf.Iterable[T]) {
+	t.Helper()
+	it := itb.Iterator()
+	t.Run("before first MoveNext", func(t *testing.T) {
+		assert.Zero(t, it.Current())
+	})
+	t.Run("after gone last MoveNext", func(t *testing.T) {
+		assert := assert.New(t)
+		for it.MoveNext() {
+		}
+		assert.False(it.MoveNext())
+		assert.Zero(it.Current())
+	})
+}

--- a/concat_test.go
+++ b/concat_test.go
@@ -70,6 +70,10 @@ func TestConcat(t *testing.T) {
 			assert.Equal(tt.want, s)
 		})
 	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	itb = gcf.Concat(itb, gcf.FromSlice([]int{4, 5, 6}))
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleConcat() {

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -52,6 +52,10 @@ func TestDistinct(t *testing.T) {
 			assert.ElementsMatch(t, tt.want, s)
 		})
 	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3, 2, 4})
+	itb = gcf.Distinct(itb)
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleDistinct() {

--- a/filter_test.go
+++ b/filter_test.go
@@ -59,6 +59,10 @@ func TestFilter(t *testing.T) {
 		itb := gcf.Filter(nil, func(v int) bool { return true })
 		assert.Equal(t, []int{}, gcf.ToSlice(itb))
 	})
+
+	itb := gcf.FromSlice([]int{1, 2, 3, 4})
+	itb = gcf.Filter(itb, func(v int) bool { return v%2 == 0 })
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleFilter() {

--- a/map_test.go
+++ b/map_test.go
@@ -2,6 +2,7 @@ package gcf_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/meian/gcf"
@@ -133,6 +134,12 @@ func TestFlatMap(t *testing.T) {
 			assert.Equal(t, tt.want, s)
 		})
 	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3, 4})
+	itbs := gcf.Map(itb, func(v int) string {
+		return strings.Repeat("a", v)
+	})
+	testBeforeAndAfter(t, itbs)
 }
 
 func ExampleFlatMap() {

--- a/repeat_test.go
+++ b/repeat_test.go
@@ -48,6 +48,9 @@ func TestRepeat(t *testing.T) {
 			assert.Equal(tt.want, s)
 		})
 	}
+
+	itb := gcf.Repeat(1, 3)
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleRepeat() {
@@ -58,8 +61,6 @@ func ExampleRepeat() {
 }
 
 func TestRepeatIterable(t *testing.T) {
-	itb := gcf.FromSlice([]int{1, 2, 3})
-	itbe := gcf.FromSlice[int](nil)
 	tests := []struct {
 		name  string
 		itb   gcf.Iterable[int]
@@ -68,13 +69,13 @@ func TestRepeatIterable(t *testing.T) {
 	}{
 		{
 			name:  "3 times",
-			itb:   itb,
+			itb:   gcf.FromSlice([]int{1, 2, 3}),
 			count: 3,
 			want:  []int{1, 2, 3, 1, 2, 3, 1, 2, 3},
 		},
 		{
 			name:  "empty iterable",
-			itb:   itbe,
+			itb:   gcf.FromSlice[int](nil),
 			count: 3,
 			want:  []int{},
 		},
@@ -86,19 +87,19 @@ func TestRepeatIterable(t *testing.T) {
 		},
 		{
 			name:  "1 times",
-			itb:   itb,
+			itb:   gcf.FromSlice([]int{1, 2, 3}),
 			count: 1,
 			want:  []int{1, 2, 3},
 		},
 		{
 			name:  "0 times",
-			itb:   itb,
+			itb:   gcf.FromSlice([]int{1, 2, 3}),
 			count: 0,
 			want:  []int{},
 		},
 		{
 			name:  "negative times",
-			itb:   itb,
+			itb:   gcf.FromSlice([]int{1, 2, 3}),
 			count: -1,
 			want:  []int{},
 		},
@@ -112,15 +113,9 @@ func TestRepeatIterable(t *testing.T) {
 		})
 	}
 
-	// for coverage
-	t.Run("more move test", func(t *testing.T) {
-		itb := gcf.FromSlice([]int{1, 2, 3})
-		itb = gcf.RepeatIterable(itb, 2)
-		it := itb.Iterator()
-		for it.MoveNext() {
-		}
-		assert.False(t, it.MoveNext())
-	})
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	itb = gcf.RepeatIterable(itb, 2)
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleRepeatIterable() {

--- a/reverse_test.go
+++ b/reverse_test.go
@@ -45,6 +45,10 @@ func TestReverse(t *testing.T) {
 			assert.Equal(t, tt.want, gcf.ToSlice(itb))
 		})
 	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	itb = gcf.Reverse(itb)
+	testBeforeAndAfter(t, itb)
 }
 
 func ExampleReverse() {

--- a/slice_test.go
+++ b/slice_test.go
@@ -37,8 +37,6 @@ func TestFromSlice_int(t *testing.T) {
 				assert.True(it.MoveNext(), "i=%d", i)
 				assert.Equal(v, it.Current(), "i=%d", i)
 			}
-			assert.False(it.MoveNext())
-			assert.Zero(it.Current())
 
 			// test for move count
 			it = itb.Iterator()
@@ -48,6 +46,9 @@ func TestFromSlice_int(t *testing.T) {
 			assert.Len(tt.slice, itCnt)
 		})
 	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	testBeforeAndAfter(t, itb)
 }
 
 func TestFromSlice_pointer(t *testing.T) {
@@ -81,9 +82,6 @@ func TestFromSlice_pointer(t *testing.T) {
 				assert.True(it.MoveNext(), "i=%d", i)
 				assert.Equal(v, it.Current(), "i=%d", i)
 			}
-			assert.False(it.MoveNext())
-			assert.Zero(it.Current())
-			assert.False(it.MoveNext())
 
 			// test for move count
 			it = itb.Iterator()
@@ -93,6 +91,9 @@ func TestFromSlice_pointer(t *testing.T) {
 			assert.Len(tt.slice, itCnt)
 		})
 	}
+
+	itb := gcf.FromSlice([]*int{&i1, &i2, &i3})
+	testBeforeAndAfter(t, itb)
 }
 
 func TestFromSliceImmutable(t *testing.T) {
@@ -138,6 +139,9 @@ func TestFromSliceImmutable(t *testing.T) {
 		}
 		assert.Empty(t, actual)
 	})
+
+	itb := gcf.FromSliceImmutable([]int{1, 2, 3})
+	testBeforeAndAfter(t, itb)
 }
 
 func TestToSlice(t *testing.T) {


### PR DESCRIPTION
- testBeforeAndAfter を追加
    - 初回のMoveNextを呼び出す前はCurrentは常にゼロ値
    - MoveNextがfalseを返した以降はMoveNextは必ずfalseでCurrentは常にゼロ値
- 各Iterableを作る関数のテストにtestBeforeAndAfterの呼び出しを追加
- もともと個別に↑のテストをやっていた箇所があったのでそれらを削除