### PR TITLE
#10 sort implements

### DIFF
--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,72 @@
+package gcf
+
+import (
+	"constraints"
+	"sort"
+)
+
+type sortIterable[T constraints.Ordered] struct {
+	itb      Iterable[T]
+	toSorter func([]T) sorter[T]
+}
+
+type sortIterator[T constraints.Ordered] struct {
+	it       Iterator[T]
+	toSorter func([]T) sorter[T]
+	built    bool
+	current  T
+}
+
+type sorter[T any] interface {
+	sort.Interface
+	Sort()
+}
+
+type ascSlice[T constraints.Ordered] []T
+
+func (s ascSlice[T]) Len() int { return len(s) }
+
+func (s ascSlice[T]) Less(i, j int) bool { return s[i] < s[j] }
+
+func (s ascSlice[T]) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s ascSlice[T]) Sort() { sort.Sort(s) }
+
+// SortAsc makes Iterable with sorted by ascending elements.
+//
+//   itb := gcf.FromSlice([]int{1, 3, 2})
+//   itb = gcf.SortAsc(itb)
+func SortAsc[T constraints.Ordered](itb Iterable[T]) Iterable[T] {
+	if itb == nil {
+		return empty[T]()
+	}
+	toSorter := func(s []T) sorter[T] { return ascSlice[T](s) }
+	return &sortIterable[T]{itb, toSorter}
+}
+
+func (itb *sortIterable[T]) Iterator() Iterator[T] {
+	return &sortIterator[T]{itb.itb.Iterator(), itb.toSorter, false, zero[T]()}
+}
+
+func (it *sortIterator[T]) MoveNext() bool {
+	if !it.built {
+		it.buildSort()
+	}
+	if !it.it.MoveNext() {
+		it.current = zero[T]()
+		return false
+	}
+	it.current = it.it.Current()
+	return true
+}
+
+func (it *sortIterator[T]) Current() T {
+	return it.current
+}
+
+func (it *sortIterator[T]) buildSort() {
+	s := iteratorToSlice(it.it)
+	it.toSorter(s).Sort()
+	it.it = makeSliceIterator(s)
+	it.built = true
+}

--- a/sort.go
+++ b/sort.go
@@ -32,6 +32,16 @@ func (s ascSlice[T]) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (s ascSlice[T]) Sort() { sort.Sort(s) }
 
+type descSlice[T constraints.Ordered] []T
+
+func (s descSlice[T]) Len() int { return len(s) }
+
+func (s descSlice[T]) Less(i, j int) bool { return s[i] > s[j] }
+
+func (s descSlice[T]) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s descSlice[T]) Sort() { sort.Sort(s) }
+
 // SortAsc makes Iterable with sorted by ascending elements.
 //
 //   itb := gcf.FromSlice([]int{1, 3, 2})
@@ -41,6 +51,18 @@ func SortAsc[T constraints.Ordered](itb Iterable[T]) Iterable[T] {
 		return empty[T]()
 	}
 	toSorter := func(s []T) sorter[T] { return ascSlice[T](s) }
+	return &sortIterable[T]{itb, toSorter}
+}
+
+// SortDesc makes Iterable with sorted by descending elements.
+//
+//   itb := gcf.FromSlice([]int{1, 3, 2})
+//   itb = gcf.SortDesc(itb)
+func SortDesc[T constraints.Ordered](itb Iterable[T]) Iterable[T] {
+	if itb == nil {
+		return empty[T]()
+	}
+	toSorter := func(s []T) sorter[T] { return descSlice[T](s) }
 	return &sortIterable[T]{itb, toSorter}
 }
 

--- a/sort_test.go
+++ b/sort_test.go
@@ -80,6 +80,78 @@ func TestSortAsc(t *testing.T) {
 	testBeforeAndAfter(t, itb)
 }
 
+func TestSortDesc(t *testing.T) {
+	type args struct {
+		itb gcf.Iterable[int]
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "sorted slice",
+			args: args{
+				itb: gcf.FromSlice([]int{1, 3, 5, 7, 9}),
+			},
+			want: []int{9, 7, 5, 3, 1},
+		},
+		{
+			name: "reverse slice",
+			args: args{
+				itb: gcf.FromSlice([]int{9, 7, 5, 3, 1}),
+			},
+			want: []int{9, 7, 5, 3, 1},
+		},
+		{
+			name: "duplicated slice",
+			args: args{
+				itb: gcf.FromSlice([]int{2, 4, 3, 5, 2, 4, 7, 6, 8}),
+			},
+			want: []int{8, 7, 6, 5, 4, 4, 3, 2, 2},
+		},
+		{
+			name: "same elements only",
+			args: args{
+				itb: gcf.FromSlice([]int{2, 2, 2, 2, 2}),
+			},
+			want: []int{2, 2, 2, 2, 2},
+		},
+		{
+			name: "1 element",
+			args: args{
+				itb: gcf.FromSlice([]int{2}),
+			},
+			want: []int{2},
+		},
+		{
+			name: "empty",
+			args: args{
+				itb: gcf.FromSlice[int](nil),
+			},
+			want: []int{},
+		},
+		{
+			name: "nil",
+			args: args{
+				itb: nil,
+			},
+			want: []int{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			itb := gcf.SortDesc(tt.args.itb)
+			s := gcf.ToSlice(itb)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	itb = gcf.SortDesc(itb)
+	testBeforeAndAfter(t, itb)
+}
+
 func FuzzSortAsc(f *testing.F) {
 	tests := [][]byte{
 		{1, 2, 3},
@@ -102,6 +174,12 @@ func FuzzSortAsc(f *testing.F) {
 			v0, v1 := sa[i], sa[i+1]
 			assert.LessOrEqualf(v0, v1, "src: %v, i: %d", s, i)
 		}
+		itbd := gcf.SortDesc(itb)
+		sd := gcf.ToSlice(itbd)
+		for i := range sd[:len(sd)-1] {
+			v0, v1 := sd[i], sd[i+1]
+			assert.GreaterOrEqualf(v0, v1, "src: %v, i: %d", s, i)
+		}
 	})
 }
 
@@ -111,4 +189,12 @@ func ExampleSortAsc() {
 	fmt.Println(gcf.ToSlice(itb))
 	// Output:
 	// [1 2 3 4 5 5 6 6 7]
+}
+
+func ExampleSortDesc() {
+	itb := gcf.FromSlice([]int{3, 6, 7, 1, 5, 6, 2, 4, 5})
+	itb = gcf.SortDesc(itb)
+	fmt.Println(gcf.ToSlice(itb))
+	// Output:
+	// [7 6 6 5 5 4 3 2 1]
 }

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,114 @@
+package gcf_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/meian/gcf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortAsc(t *testing.T) {
+	type args struct {
+		itb gcf.Iterable[int]
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "sorted slice",
+			args: args{
+				itb: gcf.FromSlice([]int{1, 3, 5, 7, 9}),
+			},
+			want: []int{1, 3, 5, 7, 9},
+		},
+		{
+			name: "reverse slice",
+			args: args{
+				itb: gcf.FromSlice([]int{9, 7, 5, 3, 1}),
+			},
+			want: []int{1, 3, 5, 7, 9},
+		},
+		{
+			name: "duplicated slice",
+			args: args{
+				itb: gcf.FromSlice([]int{2, 4, 3, 5, 2, 4, 7, 6, 8}),
+			},
+			want: []int{2, 2, 3, 4, 4, 5, 6, 7, 8},
+		},
+		{
+			name: "same elements only",
+			args: args{
+				itb: gcf.FromSlice([]int{2, 2, 2, 2, 2}),
+			},
+			want: []int{2, 2, 2, 2, 2},
+		},
+		{
+			name: "1 element",
+			args: args{
+				itb: gcf.FromSlice([]int{2}),
+			},
+			want: []int{2},
+		},
+		{
+			name: "empty",
+			args: args{
+				itb: gcf.FromSlice[int](nil),
+			},
+			want: []int{},
+		},
+		{
+			name: "nil",
+			args: args{
+				itb: nil,
+			},
+			want: []int{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			itb := gcf.SortAsc(tt.args.itb)
+			s := gcf.ToSlice(itb)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+
+	itb := gcf.FromSlice([]int{1, 2, 3})
+	itb = gcf.SortAsc(itb)
+	testBeforeAndAfter(t, itb)
+}
+
+func FuzzSortAsc(f *testing.F) {
+	tests := [][]byte{
+		{1, 2, 3},
+		{3, 2, 1},
+		{1, 3, 2},
+		{1, 1, 1},
+	}
+	for _, tt := range tests {
+		f.Add(tt)
+	}
+	f.Fuzz(func(t *testing.T, s []byte) {
+		assert := assert.New(t)
+		if len(s) < 2 {
+			return
+		}
+		itb := gcf.FromSlice(s)
+		itba := gcf.SortAsc(itb)
+		sa := gcf.ToSlice(itba)
+		for i := range sa[:len(sa)-1] {
+			v0, v1 := sa[i], sa[i+1]
+			assert.LessOrEqualf(v0, v1, "src: %v, i: %d", s, i)
+		}
+	})
+}
+
+func ExampleSortAsc() {
+	itb := gcf.FromSlice([]int{3, 6, 7, 1, 5, 6, 2, 4, 5})
+	itb = gcf.SortAsc(itb)
+	fmt.Println(gcf.ToSlice(itb))
+	// Output:
+	// [1 2 3 4 5 5 6 6 7]
+}


### PR DESCRIPTION
- gcf.SortAsc と gcf.SortDesc の実装
    - int/float64/stringは sort パッケージのそれぞれ固有の実装を使用する
        - DESC の場合は↑使ってReverseするか sort.Slice 使うか早い方を採用する