### PR TITLE
Docker image beta2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,18 @@
-FROM golang:1.18beta2-bullseye
+FROM golang:1.18beta2-bullseye as env-builder
+
+RUN go install github.com/posener/complete/gocomplete@latest \
+    && go install github.com/766b/go-outliner@latest \
+    && go install github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
+    && go install github.com/ramya-rao-a/go-outline@latest \
+    && go install github.com/cweill/gotests/gotests@latest \
+    && go install github.com/fatih/gomodifytags@latest \
+    && go install github.com/josharian/impl@latest \
+    && go install github.com/haya14busa/goplay/cmd/goplay@latest \
+    && go install github.com/go-delve/delve/cmd/dlv@latest \
+    && go install honnef.co/go/tools/cmd/staticcheck@latest \
+    && go install golang.org/x/tools/gopls@latest
+
+FROM golang:1.18beta2-bullseye as dev
 
 ENV USER vscode
 
@@ -10,6 +24,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN adduser ${USER}
 USER ${USER}
 
-RUN go install github.com/posener/complete/gocomplete@latest \
-    && gocomplete -install -y \
-    && go install github.com/766b/go-outliner@latest
+# If you don't needs tools, comment out this lines.
+COPY --from=env-builder /go/bin /go/bin
+RUN gocomplete -install -y

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-rc-buster
+FROM golang:1.18beta2-bullseye
 
 ENV USER vscode
 


### PR DESCRIPTION
- Go1.18 Beta2が出たのでDockerfile上のイメージを更新した
- vscodeのアドイン用のツールをプリインストールするようにした