### PR TITLE
#89 Block merge with fixup in CI 

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Closes #89

### What changed

Add Block fixup commit merge action.  
By ci edit only, no tests are updated.

### Others

----

### Checklist

- [x] **Issue is linked.**
    - It is not needed if simple edit such as corrections of words, etc.
- [ ] **Test is added.**
    - If fixed bug, add case on existing test or add new test.
    - If add new feature, add new test.
    - Add benchmark test, as needed.
- [x] **Test coverage rate has no decreased.**
    - If rate is decreased, explain why in What changed.
