### PR TITLE
#6 Fix docker directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/.devcontainer"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Closes #6

### What changed

- Fix docker target directory on dependabot.
    - `/` to `/.devcontainer`

### Others

----

### Checklist

- [x] **Issue is linked.**
    - It is not needed if simple edit such as corrections of words, etc.
- [ ] **Test is added.**
    - If fixed bug, add case on existing test or add new test.
    - If add new feature, add new test.
    - Add benchmark test, as needed.
- [ ] **Test coverage rate has no decreased.**
    - If rate is decreased, explain why in What changed.
